### PR TITLE
fix install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,10 +12,7 @@ if [ -z "${PREFIX}" ]; then
 fi
 
 ETC_PATH="${PREFIX}/etc/pyenv.d"
-LIBEXEC_PATH="${PREFIX}/libexec"
 
 mkdir -p "$ETC_PATH"
-mkdir -p "$LIBEXEC_PATH"
 
 cp -RPp etc/pyenv.d/* "$ETC_PATH"
-install -p libexec/* "$LIBEXEC_PATH"


### PR DESCRIPTION
Remove the `libexec/*` part as it's not existed which will emit error.
