### PR TITLE
Use custom ccache location

### DIFF
--- a/etc/pyenv.d/install/ccache.bash
+++ b/etc/pyenv.d/install/ccache.bash
@@ -43,6 +43,10 @@ setup_ccache() {
   fi
 
   export CCACHE_BASEDIR="${PYTHON_BUILD_BUILD_PATH}"
+  # Use custom cache location to avoid interfering with user's regular usage
+  #
+  # This also allows the cache to be cleared and configured seperately
+  export CCACHE_DIR=$(pyenv root)/ccache
   export CC="ccache $(command -v "$CC" || command -v "cc" || true)"
   export CXX="ccache $(command -v "$CXX" || command -v "c++" || true)"
 }

--- a/etc/pyenv.d/install/ccache.bash
+++ b/etc/pyenv.d/install/ccache.bash
@@ -43,9 +43,7 @@ setup_ccache() {
   fi
 
   export CCACHE_BASEDIR="${PYTHON_BUILD_BUILD_PATH}"
-  # Use custom cache location to avoid interfering with user's regular usage
-  #
-  # This also allows the cache to be cleared and configured seperately
+  # Use custom cache location to allow the cache be cleared and configured separately
   export CCACHE_DIR=$(pyenv root)/ccache
   export CC="ccache $(command -v "$CC" || command -v "cc" || true)"
   export CXX="ccache $(command -v "$CXX" || command -v "c++" || true)"


### PR DESCRIPTION
Set a custom ccache location for python builds.

This will avoid interfering with user's regular usage of ccache (if any).

It also makes it easier to clear and configure the cache for python builds seperately from the main one.
